### PR TITLE
Include exception headers

### DIFF
--- a/tests/auto/unit/orm/schema/mysql_schemabuilder/tst_mysql_schemabuilder.cpp
+++ b/tests/auto/unit/orm/schema/mysql_schemabuilder/tst_mysql_schemabuilder.cpp
@@ -2,6 +2,7 @@
 #include <QtTest>
 
 #include "orm/db.hpp"
+#include "orm/exceptions/logicerror.hpp"
 #include "orm/schema.hpp"
 #include "orm/utils/type.hpp"
 

--- a/tests/auto/unit/orm/schema/postgresql_schemabuilder/tst_postgresql_schemabuilder.cpp
+++ b/tests/auto/unit/orm/schema/postgresql_schemabuilder/tst_postgresql_schemabuilder.cpp
@@ -2,6 +2,8 @@
 #include <QtTest>
 
 #include "orm/db.hpp"
+#include "orm/exceptions/invalidargumenterror.hpp"
+#include "orm/exceptions/logicerror.hpp"
 #include "orm/schema.hpp"
 #include "orm/utils/type.hpp"
 

--- a/tests/auto/unit/orm/schema/postgresql_schemabuilder/tst_postgresql_schemabuilder.cpp
+++ b/tests/auto/unit/orm/schema/postgresql_schemabuilder/tst_postgresql_schemabuilder.cpp
@@ -3,7 +3,6 @@
 
 #include "orm/db.hpp"
 #include "orm/exceptions/invalidargumenterror.hpp"
-#include "orm/exceptions/logicerror.hpp"
 #include "orm/schema.hpp"
 #include "orm/utils/type.hpp"
 


### PR DESCRIPTION
The querybuilders' unit tests fail to compile due to some Exception classes being undefined if ORM compilation is disabled via cmake.

The undefined exceptions are actually being built as part of the querybuilder. However, the unit tests deep-end on models/user.hpp to include the header files for the exception classes they are using, but the corresponding include directive is skipped for builds that disable ORM.