### PR TITLE
Be less assertive in TinyOrmConfig.cmake

### DIFF
--- a/cmake/TinyOrmConfig.cmake.in
+++ b/cmake/TinyOrmConfig.cmake.in
@@ -18,7 +18,7 @@ unset(tiny_build_type)
 message(CHECK_START "Configuring @PROJECT_NAME@ package")
 list(APPEND CMAKE_MESSAGE_INDENT "  ")
 
-set_and_check(@TinyOrm_ns@_BIN_DIR "@PACKAGE_BIN_INSTALL_DIR@")
+set(@TinyOrm_ns@_BIN_DIR "@PACKAGE_BIN_INSTALL_DIR@")
 set_and_check(@TinyOrm_ns@_CONFIG_DIR "@PACKAGE_CONFIG_INSTALL_DIR@")
 set_and_check(@TinyOrm_ns@_DOC_DIR "@PACKAGE_DOC_INSTALL_DIR@")
 set_and_check(@TinyOrm_ns@_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")


### PR DESCRIPTION
Do not fail if `${TinyORM_ROOT}/bin` or `${TinyORM_ROOT}/doc` don't exist.

`bin` is only generated if a dynamic target is installed, and the result variable isn't used even if TinyORM installs a dynamic library.

On that occation, remove the assertion on `doc`, too, because documentation isn't neccessarily deployed, either.

Closes #21 