### PR TITLE
Don't redundandly copy header files

### DIFF
--- a/cmake/vcpkg/ports/tinyorm-qt5/portfile.cmake
+++ b/cmake/vcpkg/ports/tinyorm-qt5/portfile.cmake
@@ -31,11 +31,7 @@ tiny_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Install header files and license
-file(INSTALL "${SOURCE_PATH}/include/"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
-    FILES_MATCHING PATTERN *.hpp
-)
+# Install license and usage
 file(INSTALL "${SOURCE_PATH}/LICENSE"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     RENAME copyright

--- a/cmake/vcpkg/ports/tinyorm/portfile.cmake
+++ b/cmake/vcpkg/ports/tinyorm/portfile.cmake
@@ -31,11 +31,7 @@ tiny_cmake_config_fixup()
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 
-# Install header files and license
-file(INSTALL "${SOURCE_PATH}/include/"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include"
-    FILES_MATCHING PATTERN *.hpp
-)
+# Install license and usage
 file(INSTALL "${SOURCE_PATH}/LICENSE"
     DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
     RENAME copyright


### PR DESCRIPTION
The header files have already been copied when `vcpkg_cmake_install` was executed.

Closes #30 